### PR TITLE
fix: align vercel npm peer dependency install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary\n- add .npmrc with legacy-peer-deps so Vercel can install the current React/Next dependency set\n\n## Validation\n- npm run build